### PR TITLE
fix 'make docker-compose-up' to use dev conda env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,8 @@ ${DOCKER_COMPOSE_BUILD}: ${SECRET_PROPERTIES}
 # http://localhost:3000
 ###############################################################################
 docker-compose-up-no-rebuild: ${DOCKER_COMPOSE_BUILD}
-	cd build && \
+	source activate ${DEV_ENV} && \
+		cd build && \
 		docker-compose up
 	
 	


### PR DESCRIPTION
dev conda env includes docker-compose and it should be activated when running docker-compose up