### PR TITLE
updates to master deploy to qa, releases deploy to prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,15 @@ executors:
       - image: larrykirschner/circleci-elasticbeanstalk:7c095b9738d0baaea97acbaf1738db40fb0e5892
 aliases:
   # setup env vars for ebs tools
-  - &branch-env-init
-    name: Init EBS ENV
-    command: eval $EBS_TOOLS_ENV_INIT
   - &dev-mentorpal-env-init
     name: dev-mentorpal env init
     command: eval $EBS_TOOLS_ENV_INIT && echo 'export EB_ENV=dev-mentorpal' >> $BASH_ENV
+  - &qa-mentorpal-env-init
+    name: qa-mentorpal env init
+    command: eval $EBS_TOOLS_ENV_INIT && echo 'export EB_ENV=qa-mentorpal' >> $BASH_ENV
+  - &prod-mentorpal-env-init
+    name: qa-mentorpal env init
+    command: eval $EBS_TOOLS_ENV_INIT && echo 'export EB_ENV=prod-mentorpal' >> $BASH_ENV
   - &docker-build
     name: Docker Build
     command: cd ${EBS_TOOLS} && make docker-build
@@ -20,16 +23,15 @@ aliases:
   - &eb-deploy
     name: EBS Deploy
     command: cd ${EBS_TOOLS} && make clean eb-deploy
-  - &ignore-ebs-env-branches
-    branches:
-      ignore:
-        - qa-mentorpal
-        - prod-mentorpal
-  - &only-ebs-env-branches
+  - &only-master
     branches:
       only:
-        - qa-mentorpal
-        - prod-mentorpal
+        - master
+  - &only-prod-releases
+    tags:
+      only: /v[0-9]+(\.[0-9]+)*(-prod)/
+    branches:
+      ignore: /.*/
 jobs:
   test:
     docker:
@@ -48,23 +50,29 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - checkout
-      - run: *branch-env-init
+      - run: *qa-mentorpal-env-init
       - run: *docker-build
       - run:
           name: Test Images
           command: make test-images
       - run: *docker-push
-  ebs-deploy-dev:
+  dev-ebs-deploy:
     executor: ebs
     steps:
       - checkout
       - run: *dev-mentorpal-env-init
       - run: *eb-deploy
-  ebs-deploy-branch-env:
+  qa-ebs-deploy:
     executor: ebs
     steps:
       - checkout
-      - run: *branch-env-init
+      - run: *qa-mentorpal-env-init
+      - run: *eb-deploy
+  prod-ebs-deploy:
+    executor: ebs
+    steps:
+      - checkout
+      - run: *prod-mentorpal-env-init
       - run: *eb-deploy
 workflows:
   version: 2
@@ -76,19 +84,16 @@ workflows:
             - test
       - deploy-to-dev:
           type: approval
-          filters: *ignore-ebs-env-branches
           requires:
             - docker-build-test-push
-      - ebs-deploy-dev:
+      - dev-ebs-deploy:
           requires:
             - deploy-to-dev
-          filters: *ignore-ebs-env-branches
-      - deploy-to-branch-env:
-          type: approval
-          filters: *only-ebs-env-branches
+      - qa-ebs-deploy:
+          filters: *only-master
           requires:
             - docker-build-test-push
-      - ebs-deploy-branch-env:
+      - prod-ebs-deploy:
+          filters: *only-prod-releases
           requires:
-            - deploy-to-branch-env
-          filters: *only-ebs-env-branches
+            - docker-build-test-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   ebs:
     docker:
-      - image: larrykirschner/circleci-elasticbeanstalk:7c095b9738d0baaea97acbaf1738db40fb0e5892
+      - image: larrykirschner/circleci-elasticbeanstalk:e9f1c61a9c863a520f88172e076615966a12f383
 aliases:
   # setup env vars for ebs tools
   - &dev-mentorpal-env-init

--- a/ebs/README.md
+++ b/ebs/README.md
@@ -1,39 +1,54 @@
 # Deploying to AWS - Elastic Beanstalk
 
-This document covers deploying a multicontainer-docker app to AWS Elastic Beanstalk using the make rules found in this directory. These deployment scripts use a convention-over-configuration approach, so they should work similarly in any project where you find this deployment set up.
+This document covers deploying a multicontainer-docker app to AWS Elastic Beanstalk using CircleCI
 
-## The Deployment Process at a high level
+## Publishing to DEV
 
-Assuming you've created a target application and environment in Elastic Beanstalk via the console. The following steps execute a deployment:
+The method to publish to dev.mentorpal.org is now this:
 
- - Checkout the branch for the target env
+  - create a new branch *from* `master`
+      
+      ```
+      git fetch --all  # get all the latest from github
+      git checkout master   # switch to the master branch
+      git pull  # update your local master clone to latest
+      git checkout -b <my_new_branch_name>  # create a new branch from master
+      ```
+
+  - make your changes and then push to https://dev.mentorpal.org (Elastic Beanstalk env, `dev-mentorpal`) with
+
+      ```
+      git push origin <my_new_branch_name>
+      ```
+
+      Then on [github](https://github.com/ICTLearningSciences/MentorPAL/) create a pull request. At the bottom of the pull request you will see a list of CircleCi jobs that should include these:
+      
+        - deploy-to-dev 
+
+            Publishes the PR branch to the Elastic Beanstalk environment that runs https://dev.mentorpal.org.
+
+            You must manually trigger this deployment as follows: 
+
+              - Click `Details` at the right of the job in github to open this workflow in CircleCI
+              - Tap the first node to open the Approve dialog
+              - Tap `Approve` to start the deployment
+
+## Publishing to QA
+
+The method to publish to https://qa.mentorpal.org is now this:
+
+ - Create a pull request and publish to dev.mentorpal.org following the instructions above
+ - Request a review on the pull request
+ - Once approved, merge the PR branch back to `master` using the `Squash and Merge` option
+
+ The deployment to `qa-mentorpal` will run automatically when master has been updated with the new merge commit
   
-    ```bash
-    git checkout <ENV_NAME>
-    ```
+## Publishing to PRODUCTION
 
- - Make sure the branch is up to date with whatever you're intending to deploy
-    ```bash
-    git checkout development
-    git pull
-    git checkout <ENV_NAME>
-    git merge development
-    ```
+The method to publish to https://mentorpal.org is now this:
 
- - If the branch was not already up to date with development (or whatever branch or tag you're trying to deploy), make sure to test locally before deploying
- 
- - Build clean docker images, tagged with the commit hash of the deployment
+ - Publish to dev and then qa as described above
+ - Have QA test and approve the new version
+ - Once approved, create a tag. The tag must has this format `v[0-9]+(\.[0-9]+)*(-prod)`
 
-   ```bash
-   make clean docker-build
-   ``` 
-
- - Push those docker tags to docker hub (or whatever registry)
-   ```bash
-   make docker-push
-   ``` 
-
-- Execute the deployment to Elastic Beanstalk
-   ```bash
-   make clean eb-deploy
-   ``` 
+ The deployment to `prod-mentorpal` when a tag with the format above is created


### PR DESCRIPTION
Updates CI to reflect the branch/deploy model on our other projects where merges to `master` trigger deployments to QA.

Following this update we should:

1) get rid of the old `qa-mentorpal` and `development` branches (already merged to `master`)
2) move this repo over to https://github.com/ICTLearningSciences