### PR TITLE
Make develop configures mentor api url

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,5 @@
 node_modules
 public
 static
+build
 .venv

--- a/client/Makefile
+++ b/client/Makefile
@@ -1,0 +1,10 @@
+.env.development:
+	@echo "MENTOR_API_URL=https://dev.mentorpal.org/mentor-api" > .env.development
+	@echo "Set up  a default .env.development file"
+	@echo "that configures MENTOR_API_URL=https://dev.mentorpal.org/mentor-api."
+	@echo "This file should not be committed. "
+	@echo "Feel free to change to point to a local server if you're running one."
+
+
+develop: .env.development
+	gatsby develop


### PR DESCRIPTION
on a clean checkout, `make develop` will set up a `.env.development` file in your clone with

```
MENTOR_API_URL=http://dev.mentorpal.org/mentor-api
```

TODO: maybe we should also ensure that `gatsby` is installed?