### PR TITLE
adds job to run reports tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,17 @@ jobs:
       - run:
           name: Audit js
           command: make audit-js
+  reports-test:
+    docker:
+      - image: circleci/node:12.4
+    steps:
+      - checkout
+      - run:
+          name: Test reports
+          command: |
+            cd reports
+            npm install 
+            npm test
   docker-build-test-push:
     executor: ebs
     steps:
@@ -91,6 +102,7 @@ workflows:
     jobs:
       - format-and-lint-python
       - format-lint-and-audit-js
+      - reports-test
       - docker-build-test-push:
           requires:
             - format-and-lint-python

--- a/reports/Makefile
+++ b/reports/Makefile
@@ -22,8 +22,9 @@ report/mentor-answered-watched/since-%/report.json: report/mentor-answered-watch
 
 .SECONDARY:
 report/mentor-answered-watched/since-%/report.csv: report/mentor-answered-watched/since-%/report.json
-	npx json2csv -i report/mentor-answered-watched/since-$*/report.json > \
-		report/mentor-answered-watched/since-$*/report.csv
+	mkdir -p report/mentor-answered-watched/since-$*
+	npm run report:json2csv -- \
+		--dir=report/mentor-answered-watched/since-$*
 	
 
 report/mentor-answered-watched/since-%: report/mentor-answered-watched/since-%/report.csv

--- a/reports/package.json
+++ b/reports/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "npx mocha --full-trace --recursive --reporter spec",
     "report:query-xapi": "node scripts/query-xapi",
-    "report:xapi2json": "node scripts/xapi2json"
+    "report:xapi2json": "node scripts/xapi2json",
+    "report:json2csv": "node scripts/json2csv"
   },
   "author": "",
   "license": "ISC",

--- a/reports/scripts/json2csv.js
+++ b/reports/scripts/json2csv.js
@@ -1,0 +1,18 @@
+const path = require('path');
+const program = require('commander');
+const fs = require('fs-extra');
+
+const {
+  reportJsonToCsv,
+} = require('./reports/mentor_answers_watched/report');
+
+program
+  .version('1.0.0')
+  .option('-d, --dir [dir]', 'dir')
+  .parse(process.argv);
+
+const jsonPath = path.join(program.dir, 'report.json');
+const json = JSON.parse(fs.readFileSync(jsonPath));
+const resultPath = path.join(program.dir, 'report.csv');
+const csv = reportJsonToCsv(json)
+fs.writeFileSync(resultPath, csv);

--- a/reports/scripts/json2csv.js
+++ b/reports/scripts/json2csv.js
@@ -2,9 +2,7 @@ const path = require('path');
 const program = require('commander');
 const fs = require('fs-extra');
 
-const {
-  reportJsonToCsv,
-} = require('./reports/mentor_answers_watched/report');
+const { reportJsonToCsv } = require('./reports/mentor_answers_watched/report');
 
 program
   .version('1.0.0')
@@ -14,5 +12,5 @@ program
 const jsonPath = path.join(program.dir, 'report.json');
 const json = JSON.parse(fs.readFileSync(jsonPath));
 const resultPath = path.join(program.dir, 'report.csv');
-const csv = reportJsonToCsv(json)
+const csv = reportJsonToCsv(json);
 fs.writeFileSync(resultPath, csv);

--- a/reports/scripts/reports/mentor_answers_watched/report.js
+++ b/reports/scripts/reports/mentor_answers_watched/report.js
@@ -1,3 +1,4 @@
+const { parse } = require('json2csv');
 const xapi = require('./xapi');
 const {
   getObjectId,
@@ -86,6 +87,28 @@ function statementsToReportJson(statements) {
   return result;
 }
 
+const FIELDS = [
+  'answer_confidence',
+  'answer_text',
+  'mentor',
+  'question_index',
+  'question_text',
+  'resource_id',
+  'session_id',
+  'user_domain',
+  'user_id',
+  'user_name',
+];
+
+function reportJsonToCsv(reportJson) {
+  try {
+    const csv = parse(reportJson, { fields: FIELDS });
+    return csv;
+  } catch (err) {
+    console.error(err);
+  }
+}
+
 async function runReport({ since = '2019-07-31T00:00:00Z' } = {}) {
   const statements = await xapi.queryXapi({ since });
   const reportJson = statementsToReportJson(statements);
@@ -93,6 +116,7 @@ async function runReport({ since = '2019-07-31T00:00:00Z' } = {}) {
 }
 
 module.exports = {
+  reportJsonToCsv,
   runReport,
   statementsToReportJson,
 };


### PR DESCRIPTION
Update ci config to run tests for reports

  - fails a commit if tests for `reports` fail
  - fixes report tests to run without needing XAPI credentials (XAPI is mocked in tests)
  - fixes report to succeed even when result is empty (this requires specifying the field names rather than deriving them from intermediate json results)

NOTE: currently report scripts/make rules are all hard-coded to run a specific report. This is because there is only one report type right now. When we add a second report type, will update scripts to take `<which_report>` as a param