### PR TITLE
testing without autoscroll

### DIFF
--- a/client/src/components/input.jsx
+++ b/client/src/components/input.jsx
@@ -12,7 +12,6 @@ const Input = ({ height, ...props }) => {
   const dispatch = useDispatch();
   const question = useSelector(state => state.current_question);
   const [text, setText] = useState("");
-  const input = React.createRef();
   const { classes } = props;
 
   // Input field should be updated (user typed a question or selected a topic)
@@ -34,7 +33,7 @@ const Input = ({ height, ...props }) => {
     }
     dispatch(sendQuestion(text));
     setText("");
-    input.current.blur();
+    window.focus();
   };
 
   // Input field key was entered (check if user hit enter)
@@ -63,7 +62,6 @@ const Input = ({ height, ...props }) => {
       <div className="footer" style={{ height: "60px" }}>
         <Paper className={classes.root} square>
           <InputBase
-            ref={input}
             className={classes.inputField}
             value={text}
             multiline

--- a/client/src/components/input.jsx
+++ b/client/src/components/input.jsx
@@ -12,6 +12,7 @@ const Input = ({ height, ...props }) => {
   const dispatch = useDispatch();
   const question = useSelector(state => state.current_question);
   const [text, setText] = useState("");
+  const input = React.createRef();
   const { classes } = props;
 
   // Input field should be updated (user typed a question or selected a topic)
@@ -33,6 +34,7 @@ const Input = ({ height, ...props }) => {
     }
     dispatch(sendQuestion(text));
     setText("");
+    input.current.blur();
   };
 
   // Input field key was entered (check if user hit enter)
@@ -61,6 +63,7 @@ const Input = ({ height, ...props }) => {
       <div className="footer" style={{ height: "60px" }}>
         <Paper className={classes.root} square>
           <InputBase
+            ref={input}
             className={classes.inputField}
             value={text}
             multiline

--- a/client/src/components/questions.jsx
+++ b/client/src/components/questions.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { List } from "@material-ui/core";
 import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
 
 import ScrollingQuestions from "components/scrolling-questions";
@@ -42,14 +41,13 @@ const Questions = ({ height, onSelected }) => {
 
   return (
     <MuiThemeProvider theme={theme}>
-      <List disablePadding style={{ maxHeight: height, overflow: "auto" }}>
-        <ScrollingQuestions
-          questions={questions}
-          questions_asked={questions_asked}
-          recommended={recommended}
-          onQuestionSelected={onSelected}
-        />
-      </List>
+      <ScrollingQuestions
+        height={height}
+        questions={questions}
+        questions_asked={questions_asked}
+        recommended={recommended}
+        onQuestionSelected={onSelected}
+      />
     </MuiThemeProvider>
   );
 };

--- a/client/src/components/scrolling-questions.jsx
+++ b/client/src/components/scrolling-questions.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from "react";
-import { ListItem, ListItemText } from "@material-ui/core";
+import { List, ListItem, ListItemText } from "@material-ui/core";
 import { Whatshot } from "@material-ui/icons";
 
 import { normalizeString } from "funcs/funcs";
 
 const ScrollingQuestions = ({
+  height,
   questions,
   questions_asked,
   recommended,
@@ -14,41 +15,45 @@ const ScrollingQuestions = ({
     const top_question = questions.find(q => {
       return !questions_asked.includes(normalizeString(q));
     });
-
+    const parent = document.getElementById("scrolling-questions-list");
     const node = document.getElementById(top_question);
-    if (!(top_question && node)) {
+    if (!(parent && node)) {
       return;
     }
+    parent.scrollTop = node.offsetTop;
+  }, [questions, questions_asked]);
 
-    node.scrollIntoView({
-      behavior: "smooth",
-      block: "start",
-    });
-  });
-
-  return questions.map((question, i) => (
-    <ListItem
-      key={i}
-      id={question}
-      onClick={() => onQuestionSelected(question)}
+  return (
+    <List
+      id="scrolling-questions-list"
+      className="scroll"
+      style={{ maxHeight: height }}
     >
-      <ListItemText
-        style={{
-          paddingLeft: 0,
-          color: questions_asked.includes(normalizeString(question))
-            ? "gray"
-            : "black",
-        }}
-      >
-        {recommended.includes(question) ? (
-          <Whatshot style={{ marginRight: "5px" }} fontSize="small" />
-        ) : (
-          undefined
-        )}
-        {question}
-      </ListItemText>
-    </ListItem>
-  ));
+      {questions.map((question, i) => (
+        <ListItem
+          key={i}
+          id={question}
+          onClick={() => onQuestionSelected(question)}
+        >
+          <ListItemText
+            style={{
+              paddingLeft: 0,
+              color: questions_asked.includes(normalizeString(question))
+                ? "gray"
+                : "black",
+            }}
+          >
+            {recommended.includes(question) ? (
+              <Whatshot style={{ marginRight: "5px" }} fontSize="small" />
+            ) : (
+              undefined
+            )}
+            {question}
+          </ListItemText>
+        </ListItem>
+      ))}
+    </List>
+  );
 };
 
 export default ScrollingQuestions;

--- a/client/src/components/scrolling-questions.jsx
+++ b/client/src/components/scrolling-questions.jsx
@@ -20,7 +20,11 @@ const ScrollingQuestions = ({
     if (!(parent && node)) {
       return;
     }
-    parent.scrollTop = node.offsetTop;
+    parent.scrollTo({
+      behavior: "smooth",
+      top: node.offsetTop,
+      left: 0,
+    });
   }, [questions, questions_asked]);
 
   return (
@@ -28,6 +32,7 @@ const ScrollingQuestions = ({
       id="scrolling-questions-list"
       className="scroll"
       style={{ maxHeight: height }}
+      disablePadding
     >
       {questions.map((question, i) => (
         <ListItem

--- a/client/src/styles/layout.css
+++ b/client/src/styles/layout.css
@@ -2,6 +2,7 @@ body {
   height: 100%;
   margin: 0;
   text-align: center;
+  -webkit-overflow-scrolling: touch;
 }
 #video-container {
   position: relative;
@@ -24,15 +25,18 @@ body {
 }
 .expand {
   flex: 1 1;
-  -webkit-overflow-scrolling: touch;
+}
+.scroll {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;    
 }
 
 .carousel {
   width: 100%;
   overflow-x: visible;
   overflow-y: hidden;
-  white-space: nowrap;
   -webkit-overflow-scrolling: touch;
+  white-space: nowrap;
 }
 .carousel .slide {
   position: relative;


### PR DESCRIPTION
Fixes the bug where topic and panel buttons were unclickable on iPhone X in PAL3

Smooth scrolling of questions list works in FireFox and Chrome, but not in Safari.

In Safari (iOS), the question list will jump to the top question without a smooth scroll.

In Safari (iOS), if the user is manually scrolling the question list while switching topic or mentor, will not autoscroll because manual scroll overrides auto scroll. If the list is not actively scrolling when switching, auto scroll works fine.