### PR TITLE
Testing smoothscroll npm package

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16361,6 +16361,11 @@
         }
       }
     },
+    "smoothscroll-polyfill": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
+      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "redux-cmi5": "github:beatthat/redux-cmi5#semver:^1.3.3",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
+    "smoothscroll-polyfill": "^0.4.4",
     "typescript": "^3.5.3"
   },
   "devDependencies": {

--- a/client/src/components/scrolling-questions.jsx
+++ b/client/src/components/scrolling-questions.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { List, ListItem, ListItemText } from "@material-ui/core";
 import { Whatshot } from "@material-ui/icons";
-import smoothscroll from 'smoothscroll-polyfill';
+import smoothscroll from "smoothscroll-polyfill";
 
 import { normalizeString } from "funcs/funcs";
 

--- a/client/src/components/scrolling-questions.jsx
+++ b/client/src/components/scrolling-questions.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { List, ListItem, ListItemText } from "@material-ui/core";
 import { Whatshot } from "@material-ui/icons";
+import smoothscroll from 'smoothscroll-polyfill';
 
 import { normalizeString } from "funcs/funcs";
 
@@ -11,6 +12,10 @@ const ScrollingQuestions = ({
   recommended,
   onQuestionSelected,
 }) => {
+  useEffect(() => {
+    smoothscroll.polyfill();
+  }, []);
+
   useEffect(() => {
     const top_question = questions.find(q => {
       return !questions_asked.includes(normalizeString(q));


### PR DESCRIPTION
Safari smooth scrolls to make it consistent with Chrome and Firefox. If we don't want smooth scroll, I can disable it for everyone.