### PR TITLE
Client uses runtime configured video host

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7271,7 +7271,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7289,11 +7290,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7306,15 +7309,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7417,7 +7423,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7427,6 +7434,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7439,17 +7447,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7466,6 +7477,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7538,7 +7550,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7548,6 +7561,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7623,7 +7637,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7653,6 +7668,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7670,6 +7686,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7708,11 +7725,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -10059,12 +10078,14 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "slice-ansi": {
           "version": "1.0.0",
@@ -10090,6 +10111,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -12264,7 +12286,8 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -12287,6 +12310,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -15979,6 +16003,7 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "optional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/client/package.json
+++ b/client/package.json
@@ -76,8 +76,8 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build --prefix-paths",
-    "develop": "gatsby develop",
+    "build": "npx gatsby build --prefix-paths",
+    "develop": "npx gatsby develop",
     "format": "prettier --write '**/*.{js,jsx,json,ts,tsx}'",
     "start": "npm run develop",
     "serve": "gatsby serve",

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -12,18 +12,19 @@ It exists (at least for now), exclusively to enable
 dev-local clients where mentor videos are being polished
 to test serving those videos
 */
-if(typeof(window) !== 'undefined') { // i.e. don't run at build time
+if (typeof window !== "undefined") {
+  // i.e. don't run at build time
   axios
-  .get(`${MENTOR_API_URL}/config/video-host`)
-  .then(result => {
-    console.log(`get ${MENTOR_API_URL}/config/video-host`, result);
-    if (typeof result.data.url === "string") {
-      MENTOR_VIDEO_HOST = result.data.url;
-    }
-  })
-  .catch(err => {
-    console.error(err);
-  });
+    .get(`${MENTOR_API_URL}/config/video-host`)
+    .then(result => {
+      console.log(`get ${MENTOR_API_URL}/config/video-host`, result);
+      if (typeof result.data.url === "string") {
+        MENTOR_VIDEO_HOST = result.data.url;
+      }
+    })
+    .catch(err => {
+      console.error(err);
+    });
 }
 
 export const videoUrl = (mentor, format) => {

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -12,7 +12,8 @@ It exists (at least for now), exclusively to enable
 dev-local clients where mentor videos are being polished
 to test serving those videos
 */
-axios
+if(typeof(window) !== 'undefined') { // i.e. don't run at build time
+  axios
   .get(`${MENTOR_API_URL}/config/video-host`)
   .then(result => {
     console.log(`get ${MENTOR_API_URL}/config/video-host`, result);
@@ -23,6 +24,7 @@ axios
   .catch(err => {
     console.error(err);
   });
+}
 
 export const videoUrl = (mentor, format) => {
   return `${MENTOR_VIDEO_HOST}/videos/mentors/${mentor.id}/${format}/${mentor.answer_id}.mp4`;

--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -1,8 +1,28 @@
 import axios from "axios";
 
 const MENTOR_API_URL = process.env.MENTOR_API_URL || "/mentor-api"; // eslint-disable-line no-undef
-const MENTOR_VIDEO_HOST = "https://video.mentorpal.org";
+let MENTOR_VIDEO_HOST =
+  process.env.MENTOR_VIDEO_HOST || "https://video.mentorpal.org";
 const RESPONSE_CUTOFF = -100;
+
+/*
+This is a hacky place and means to get a server-configured
+override of VIDEO_HOST.
+It exists (at least for now), exclusively to enable
+dev-local clients where mentor videos are being polished
+to test serving those videos
+*/
+axios
+  .get(`${MENTOR_API_URL}/config/video-host`)
+  .then(result => {
+    console.log(`get ${MENTOR_API_URL}/config/video-host`, result);
+    if (typeof result.data.url === "string") {
+      MENTOR_VIDEO_HOST = result.data.url;
+    }
+  })
+  .catch(err => {
+    console.error(err);
+  });
 
 export const videoUrl = (mentor, format) => {
   return `${MENTOR_VIDEO_HOST}/videos/mentors/${mentor.id}/${format}/${mentor.answer_id}.mp4`;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
       - mentor-api
   mentor-api:
     image: "mentorpal-mentor-api"
+    environment:
+      # we don't need to override the MENTOR_VIDEO_HOST
+      # but this is how you would do it,
+      # say, for serving locally-hosted videos
+      # - MENTOR_VIDEO_HOST=http://video.mentorpal.org
     expose:
       - "5000"
   proxy:

--- a/services/mentor-api/src/mentor_api/__init__.py
+++ b/services/mentor-api/src/mentor_api/__init__.py
@@ -48,6 +48,10 @@ def create_app(script_info=None):
 
     app.register_blueprint(ping_blueprint, url_prefix="/mentor-api/ping")
 
+    from mentor_api.blueprints.config import config_blueprint
+
+    app.register_blueprint(config_blueprint, url_prefix="/mentor-api/config")
+
     from mentor_api.blueprints.questions import create as create_questions_blueprint
 
     app.register_blueprint(

--- a/services/mentor-api/src/mentor_api/blueprints/config.py
+++ b/services/mentor-api/src/mentor_api/blueprints/config.py
@@ -1,0 +1,8 @@
+from flask import Blueprint, current_app, jsonify
+
+config_blueprint = Blueprint("config", __name__)
+
+
+@config_blueprint.route("/video-host", methods=["GET"])
+def video_host():
+    return jsonify({"url": current_app.config["MENTOR_VIDEO_HOST"]})

--- a/services/mentor-api/src/mentor_api/config_default.py
+++ b/services/mentor-api/src/mentor_api/config_default.py
@@ -5,15 +5,15 @@ class Config(object):
     SECRET_KEY = (
         os.environ.get("SECRET_KEY") or "production_servers_must_provide_a_secret_key"
     )
-
-    # override with a list of ids for mentors
-    # that should preload with the server
-    MENTOR_IDS_PRELOAD = []
-
-    MENTOR_DATA = "/app/mentors"
-
     CLASSIFIER_ARCH = os.environ.get("CLASSIFIER_ARCH") or "lstm_v1"
     CLASSIFIER_CHECKPOINT = os.environ.get("CLASSIFIER_CHECKPOINT") or "2019-06-13-1900"
     CLASSIFIER_CHECKPOINT_ROOT = (
         os.environ.get("CLASSIFIER_CHECKPOINT_ROOT") or "/app/checkpoint"
+    )
+    # override with a list of ids for mentors
+    # that should preload with the server
+    MENTOR_IDS_PRELOAD = []
+    MENTOR_DATA = "/app/mentors"
+    MENTOR_VIDEO_HOST = (
+        os.environ.get("MENTOR_VIDEO_HOST") or "https://video.mentorpal.org"
     )

--- a/services/mentor-api/tests/features/serves_config.feature
+++ b/services/mentor-api/tests/features/serves_config.feature
@@ -1,0 +1,18 @@
+Feature: Serves configuration
+
+  Scenario Outline: serves video-host
+    Given a request url http://localhost:5000/config/video-host
+      When the request sends GET
+      Then the response status is OK
+        And the response json matches
+            """
+            {
+              "title": "VideoBHostConfigResponse",
+              "type": "object",
+              "properties": {
+                  "url": {"type": "string"}
+              },
+              "required": ["url"]
+            }
+            """
+        And the response json at $.url is equal to "https://video.mentorpal.org/2"

--- a/services/web-app/Makefile
+++ b/services/web-app/Makefile
@@ -36,6 +36,17 @@ docker-run:
 		$(DOCKER_IMAGE) 
 
 
+.PHONY docker-run-shell:
+docker-run-shell:
+	docker run \
+			-it \
+			--rm \
+			--name $(DOCKER_CONTAINER) \
+			-p 3000:3000 \
+			--entrypoint /bin/bash \
+		$(DOCKER_IMAGE) 
+
+
 .PHONY docker-run-dev:
 docker-run-dev:
 	docker run \


### PR DESCRIPTION
Adds option to override the VIDEO_HOST used by the client on their local machine by setting env var `` in the `web-app` service, e.g. in `docker-compose`

```
# docker-compose.yml
services:
  mentor-api:
    image: "mentorpal-mentor-api"
    environment:
      - MENTOR_VIDEO_HOST=http://video.mentorpal.org
```

This will enable testing a local mentor (in progress) with undeployed videos