### PR TITLE
now supports source videos in two formats: 1280x720 and 1920x1080

### DIFF
--- a/mentors/.dockerignore
+++ b/mentors/.dockerignore
@@ -1,2 +1,5 @@
 Makefile
 README.md
+videos
+data
+

--- a/mentors/Dockerfile
+++ b/mentors/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:18.04
 RUN apt-get update && \
     apt-get install -y \
         ffmpeg \
+        mediainfo \
         python3.7 \
         python3-pip && \
     rm -rf /var/lib/apt/lists/*

--- a/mentors/Makefile
+++ b/mentors/Makefile
@@ -25,7 +25,7 @@ virtualenv-installed:
 
 PHONY: test
 test: $(TEST_VIRTUAL_ENV)
-	$(TEST_VIRTUAL_ENV)/bin/py.test -vv
+	PYTHONPATH=$(shell echo $${PYTHONPATH}):$(shell pwd)/src/data_pipeline $(TEST_VIRTUAL_ENV)/bin/py.test -vv
 
 .PHONY: docker-image-exists
 docker-image-exists:
@@ -112,6 +112,7 @@ shell: docker-image-exists $(WATSON_CREDENTIALS)
 	docker run \
 			--rm \
 			--name $(DOCKER_CONTAINER) \
+			-v $(shell pwd)/src:/app/src \
 			-v $(shell pwd)/$*:/app/mounts/$* \
 			-v $(shell pwd)/data:/app/mounts/data \
 			$(DOCKER_IMAGE) --mentor $* --qpa_pu_data --classification_data
@@ -131,6 +132,7 @@ update/%/videos: %/build docker-image-exists
 	docker run \
 			--rm \
 			--name $(DOCKER_CONTAINER) \
+			-v $(shell pwd)/src:/app/src \
 			-v $(shell pwd)/$*:/app/mounts/$* \
 			-v $(shell pwd)/data:/app/mounts/data \
 			-v $(shell pwd)/videos:/app/mounts/videos \

--- a/mentors/requirements.txt
+++ b/mentors/requirements.txt
@@ -5,6 +5,7 @@ gdown==3.8.1
 idna==2.8
 numpy==1.16.4
 pandas==0.24.2
+pymediainfo==4.0
 python-dateutil==2.8.0
 pytz==2019.1
 requests==2.22.0

--- a/mentors/src/data_pipeline/post_process_data/__init__.py
+++ b/mentors/src/data_pipeline/post_process_data/__init__.py
@@ -7,6 +7,7 @@ import requests
 
 import constants
 import utils
+from .utils import gen_mobile_video
 
 
 """
@@ -35,18 +36,7 @@ METADATA = constants.METADATA
 IDLE_FILE = constants.IDLE_FILE
 MENTOR_INTRO = constants.MENTOR_INTRO
 
-DATA_DIR = os.environ["DATA_MOUNT"] or os.getcwd()
-
-
-def ffmpeg_convert_mobile(input_file, output_file):
-    ff = ffmpy.FFmpeg(
-        inputs={input_file: None},
-        # outputs={output_file: "-filter:v crop=614:548:333:86 -y"},  This is for the 1280x720
-        outputs={
-            output_file: "-filter:v crop=918:822:500:220 -threads 0 -y"
-        },  # this is for 1080p  the parameters are width, height, x and y point
-    )
-    ff.run()
+DATA_DIR = os.environ.get("DATA_MOUNT") or os.getcwd()
 
 
 def ffmpeg_split_video(input_file, output_file, start_time, end_time):
@@ -60,7 +50,7 @@ def ffmpeg_split_video(input_file, output_file, start_time, end_time):
     start_time: Start time of answer
     end_time: End time of answer
     """
-    output_command = f"-ss {start_time} -to {end_time} -loglevel quiet -threads 0"
+    output_command = f"-y -ss {start_time} -to {end_time} -loglevel quiet -threads 0"
     ff = ffmpy.FFmpeg(inputs={input_file: None}, outputs={output_file: output_command})
     ff.run()
 
@@ -117,7 +107,7 @@ class PostProcessData(object):
                 web_chunk = os.path.join(mentor_videos, WEB_VIDEOS, output_file)
                 mobile_chunk = os.path.join(mentor_videos, MOBILE_VIDEOS, output_file)
                 ffmpeg_split_video(video_file, web_chunk, start_times[i], end_times[i])
-                ffmpeg_convert_mobile(web_chunk, mobile_chunk)
+                gen_mobile_video(web_chunk, mobile_chunk)
 
     def __save_answer_data__(self, mentor, session, part):
         answer_sample = {}

--- a/mentors/src/data_pipeline/post_process_data/utils.py
+++ b/mentors/src/data_pipeline/post_process_data/utils.py
@@ -1,0 +1,34 @@
+import ffmpy
+from pymediainfo import MediaInfo
+
+
+def find_video_dims(video_file):
+    media_info = MediaInfo.parse(video_file)
+    video_tracks = [t for t in media_info.tracks if t.track_type == "Video"]
+    return (
+        (video_tracks[0].width, video_tracks[0].height)
+        if len(video_tracks) >= 1
+        else (-1, -1)
+    )
+
+
+def gen_mobile_video(src_file, output_file):
+    video_dims = find_video_dims(src_file)
+    crop = None
+    if video_dims == (1280, 720):
+        crop = "614:548:333:86"
+    elif video_dims == (1920, 1080):
+        crop = "918:822:500:220"
+    if crop:
+        print(
+            f"INFO: generating mobile video {output_file} cropped with {crop} for src file {src_file} with dims {video_dims}"
+        )
+    else:
+        crop = "614:548:333:86"
+        print(
+            f"WARN: no configured for src file {src_file} with dims {video_dims} using default {crop}"
+        )
+    ff = ffmpy.FFmpeg(
+        inputs={src_file: None}, outputs={output_file: f"-filter:v crop={crop} -y"}
+    )
+    ff.run()

--- a/mentors/tests/test_gen_mobile_video.py
+++ b/mentors/tests/test_gen_mobile_video.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from post_process_data import gen_mobile_video
+
+
+class Bunch:
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)
+
+
+@patch("pymediainfo.MediaInfo.parse")
+@patch("ffmpy.FFmpeg")
+@pytest.mark.parametrize(
+    "input_video_dims,expected_crop",
+    [((1280, 720), "614:548:333:86"), ((1920, 1080), "918:822:500:220")],
+)
+def test_it_adjusts_output_crop_size_for_input_video_dims(
+    mockFFmpegCls, mockParse, input_video_dims, expected_crop
+):
+    # TODO: update test to support a wider range of arbitrary input video sizes?
+    input = "some_input_video.mp4"
+    output = "output_video_path.mp4"
+    mockParseResult = Bunch(
+        tracks=[
+            Bunch(
+                track_type="Video",
+                width=input_video_dims[0],
+                height=input_video_dims[1],
+            )
+        ]
+    )
+    mockParse.return_value = mockParseResult
+    mockFFmpegInst = Mock()
+    mockFFmpegCls.return_value = mockFFmpegInst
+    gen_mobile_video(input, output)
+    mockFFmpegCls.assert_called_once_with(
+        inputs={input: None}, outputs={output: f"-filter:v crop={expected_crop} -y"}
+    )
+    mockFFmpegInst.run.assert_called_once()

--- a/mentors/tests/test_placeholder.py
+++ b/mentors/tests/test_placeholder.py
@@ -1,2 +1,0 @@
-def test_it_passes():
-    assert 1 == 1


### PR DESCRIPTION
Previously was hard coded to support only 1920x1080

  - adds support for reading video dims
  - adds test for cropping of mobile video
  - makes post_process_data a module folder to make it possible to break some code into sep files