### PR TITLE
Enables pytest for mentor api

### DIFF
--- a/services/mentor-api/Makefile
+++ b/services/mentor-api/Makefile
@@ -93,7 +93,7 @@ docker-run-dev: docker-image-exists
 			-p 5000:5000 \
 			-v $(PROJECT_ROOT)/checkpoint:/app/checkpoint \
 			-v $(PWD)/src/mentor_api:/app/mentor_api \
-			-v $(PROJECT_ROOT)/src/mentorpal:/app/mentorpal \
+			-v $(PROJECT_ROOT)/classifier/src/mentorpal:/app/mentorpal \
 		$(DOCKER_IMAGE) 
 
 
@@ -107,7 +107,7 @@ docker-run-dev-shell: docker-image-exists
 			-p 5000:5000 \
 			-v $(PROJECT_ROOT)/checkpoint:/app/checkpoint \
 			-v $(PWD)/src/mentor_api:/app/mentor_api \
-			-v $(PROJECT_ROOT)/src/mentorpal:/app/mentorpal \
+			-v $(PROJECT_ROOT)/classifier/src/mentorpal:/app/mentorpal \
 			--entrypoint /bin/bash \
 		$(DOCKER_IMAGE) 
 
@@ -136,17 +136,30 @@ $(TEST_VIRTUAL_ENV):
 test-env-create: $(PROJECT_ROOT)/behave-restful/setup.py virtualenv-installed
 	[ -d $(TEST_VIRTUAL_ENV) ] || virtualenv -p python3 $(TEST_VIRTUAL_ENV)
 	$(TEST_VIRTUAL_ENV_PIP) install --upgrade pip
+	$(TEST_VIRTUAL_ENV_PIP) install -r $(PROJECT_ROOT)/classifier/requirements.txt
+	$(TEST_VIRTUAL_ENV_PIP) install -r requirements.txt
 	$(TEST_VIRTUAL_ENV_PIP) install -r tests/requirements.txt
 	$(TEST_VIRTUAL_ENV_PIP) install -r $(BEHAVE_RESTFUL)/requirements.txt && \
 	$(TEST_VIRTUAL_ENV_PIP) install -e $(BEHAVE_RESTFUL)
 
+.PHONY: test-units
+test-units: $(TEST_VIRTUAL_ENV)
+	source $(TEST_VIRTUAL_ENV)/bin/activate && \
+		export PYTHONPATH=$${PYTHONPATH}:$(PROJECT_ROOT)/services/mentor-api/src:$(PROJECT_ROOT)/classifier/src && \
+		$(TEST_VIRTUAL_ENV)/bin/py.test -vv
 
-.PHONY: test
-test: $(TEST_VIRTUAL_ENV) docker-image-exists
+
+.PHONY: test-integrations
+test-integrations: $(TEST_VIRTUAL_ENV) docker-image-exists
 	source $(TEST_VIRTUAL_ENV)/bin/activate  && \
 		cd tests && \
 		export DOCKER_IMAGE=$(DOCKER_IMAGE) && \
 		bolt start-api-then-test-features
+
+.PHONY: test
+test:
+	$(MAKE) test-units
+	$(MAKE) test-integrations
 
 .PHONY: test-image-build
 test-image-build:

--- a/services/mentor-api/tests/conftest.py
+++ b/services/mentor-api/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from flask import Response
+from mentor_api import create_app
+
+
+@pytest.fixture
+def app():
+    myapp = create_app()
+    myapp.debug = True
+    myapp.response_class = Response
+    return myapp

--- a/services/mentor-api/tests/requirements.txt
+++ b/services/mentor-api/tests/requirements.txt
@@ -1,6 +1,8 @@
 assertpy
 behave==1.2.6
 bolt-ta
+pytest==5.1.2
+pytest-flask==0.15.0
 requests
 
   

--- a/services/mentor-api/tests/unit_tests/test_ping.py
+++ b/services/mentor-api/tests/unit_tests/test_ping.py
@@ -1,0 +1,5 @@
+def test_it_returns_pong_response(client):
+    res = client.get("/mentor-api/ping/")
+    assert res.status_code == 200
+    assert res.json.get("message") == "pong!"
+    assert res.json.get("status") == "success"


### PR DESCRIPTION
mentor-api already has integration tests,
which bring up the flask server with classifier data
and test the full classifier endpoints.

This commit adds unit-test support via pytest.
For some things like error handling it's
simpler and more efficent to unit test
the endpoints