### PR TITLE
fixes nltk-ssl error in docker build for classifier

### DIFF
--- a/classifier/Dockerfile
+++ b/classifier/Dockerfile
@@ -16,8 +16,10 @@ ADD requirements.txt /tmp/requirements.txt
 RUN bash -c "source activate ${MENTORPAL_CONDA_ENV} && \
     pip install -r /tmp/requirements.txt"
 RUN rm /tmp/requirements.txt
+COPY ./bin /tmp/bin
 RUN bash -c "source activate ${MENTORPAL_CONDA_ENV} && \
-    python -m nltk.downloader averaged_perceptron_tagger"
+     python /tmp/bin/nltk_setup.py" && \
+     rm -rf /tmp/bin
 
 WORKDIR /app
 

--- a/classifier/bin/nltk_setup.py
+++ b/classifier/bin/nltk_setup.py
@@ -1,0 +1,11 @@
+import nltk
+import ssl
+
+try:
+    _create_unverified_https_context = ssl._create_unverified_context
+except AttributeError:
+    pass
+else:
+    ssl._create_default_https_context = _create_unverified_https_context
+
+nltk.download("averaged_perceptron_tagger")


### PR DESCRIPTION
The step to use nltk downloader for averaged_perceptron_tagger was failing
with an SSL-cert error