### PR TITLE
enables abs imports like 'import x from @/path/without/src/prefix'

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     ".+\\.(css|styl|less|sass|scss)$": "identity-obj-proxy",
     ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/__mocks__/file-mock.js",
+    "@/(.*)$": "<rootDir>/src/$1",
   },
   modulePaths: ["<rootDir>/src/"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],

--- a/client/jsconfig.json
+++ b/client/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -40,8 +40,10 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
+    "paths": {
+      "@/*": ["src/*"]
+    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
This is so you can use absolute imports everywhere in client and NOT have to use  `src` prefix.

Imports look like this:

```
import something from '@/path/without/src/prefix`
```