### PR TITLE
fixes hard-code of classifier version in api tests

### DIFF
--- a/services/mentor-api/src/mentor_api/config_default.py
+++ b/services/mentor-api/src/mentor_api/config_default.py
@@ -7,7 +7,11 @@ class Config(object):
         os.environ.get("SECRET_KEY") or "production_servers_must_provide_a_secret_key"
     )
     CLASSIFIER_ARCH = os.environ.get("CLASSIFIER_ARCH") or "lstm_v1"
-    CLASSIFIER_CHECKPOINT = os.environ.get("CLASSIFIER_CHECKPOINT") or "2019-06-13-1900"
+    CLASSIFIER_CHECKPOINT = (
+        os.environ.get("CLASSIFIER_CHECKPOINT")
+        or os.environ.get("CHECKPOINT")
+        or "2019-06-13-1900"
+    )
     CLASSIFIER_CHECKPOINT_ROOT = os.environ.get("CLASSIFIER_CHECKPOINT_ROOT") or str(
         Path("/app/checkpoint")
     )

--- a/services/mentor-api/tests/features/mentors_answer_canned_questions.feature
+++ b/services/mentor-api/tests/features/mentors_answer_canned_questions.feature
@@ -28,7 +28,7 @@ Feature: Mentors answer canned questions
         And the response json at $.query is equal to "<query>"
         And the response json at $.answer_id is equal to "<answer_id>"
         And the response json at $.answer_text starts with "<answer_text_start>"
-        And the response json at $.classifier is equal to "lstm_v1/2019-06-13-1900"
+        And the response json at $.classifier matches "^lstm_v1/[a-zA-Z0-9\-_]+$"
   
   Examples: Queries
     | mentor    | query                                                   | answer_id                     | answer_text_start                                                                                                   |

--- a/services/mentor-api/tests/features/mentors_answer_questions.feature
+++ b/services/mentor-api/tests/features/mentors_answer_questions.feature
@@ -28,7 +28,7 @@ Feature: Mentors answer questions
         And the response json at $.query is equal to "<query>"
         And the response json at $.answer_id is equal to "<answer_id>"
         And the response json at $.answer_text starts with "<answer_text_start>"
-        And the response json at $.classifier is equal to "lstm_v1/2019-06-13-1900"
+        And the response json at $.classifier matches "^lstm_v1/[a-zA-Z0-9\-_]+$"
   
   Examples: Queries
     | mentor    | query                                               | answer_id                      | answer_text_start                                                                                                   |

--- a/services/mentor-api/tests/features/responds_to_off_topic_with_prompt.feature
+++ b/services/mentor-api/tests/features/responds_to_off_topic_with_prompt.feature
@@ -26,8 +26,8 @@ Feature: Mentors responds to off-topic question with a prompt
         And the response json at $.mentor is equal to "<mentor>"
         And the response json at $.query is equal to "<query>"
         And the response json at $.answer_id matches "<answer_id_regex>"
-        And the response json at $.classifier is equal to "lstm_v1/2019-06-13-1900"
-  
+        And the response json at $.classifier matches "^lstm_v1/[a-zA-Z0-9\-_]+$"
+        
   # for now listing all the PROMPT answers in the regex'es below. Could alternatively test that the answer just isn't garbage, e.g clintanderson_u*
   Examples: Queries
     | mentor    | query                                   | answer_id_regex |


### PR DESCRIPTION
For mentor-api, endpoint tests had been expecting a specific version of the classifier in responses

Now, updated to just match a regex